### PR TITLE
Return a promise from create method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ class Service {
 
     // https://github.com/nodemailer/nodemailer#set-up-smtp says:
     // If callback argument is not set then the method returns a Promise object.
-    return this.transporter.sendMail(body, cb);
+    return this.transporter.sendMail(body);
   }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,12 +23,14 @@ describe('feathers-mailer', () => {
         Because the revolution will not be televised.
       `
     };
-    mailer.create(mailData, {}, function (err, info) {
-      assert.ifError(err);
+    mailer.create(mailData).then(function (info) {
       assert.equal(info.envelope.from, getEmailAddress(mailData.from));
       assert.deepEqual(info.envelope.to, mailData.to.map(getEmailAddress));
       assert.ok(info.messageId);
       assert.ok(info.response.toString());
+      done();
+    }).catch(function (err) {
+      assert.ifError(err);
       done();
     });
   });


### PR DESCRIPTION
Promise that should be returned by `this.transporter.sendMail(body, cb)` call in from `create` method will never be returned.

This happens because Feathersjs uses [rubberduck](https://github.com/daffl/rubberduck) package [here](https://github.com/feathersjs/feathers/blob/master/src/mixins/event.js#L21) to receive events before and after a service method executes.

rubberduck wraps all service CRUD methods callback with [callbackWrapper function](https://github.com/daffl/rubberduck/blob/master/lib/rubberduck.js#L48-L57). At the same time [getCallback function](https://github.com/feathersjs/feathers-commons/blob/e8598240a6af9e659a620b079997658f42772129/src/arguments.js#L2-L5) assumes that [last argument](https://github.com/feathersjs/feathers-commons/blob/e8598240a6af9e659a620b079997658f42772129/src/arguments.js#L64) of the any method is the callback. The result is that `callback` argument in the `create` method will be always defined and contain `callbackWrapper` function.

My suggestion is to force `sendMail` method to always return a promise by removing `cb` argument:

```js
return this.transporter.sendMail(body);
```

This will allow us to use feathers built in service method callbacks:

```js
app.service('mailer').create(email, result => {
  console.log('Sent email', result);
});
```
As well as promises:

```js
app.service('mailer').create(email).then(result => {
  console.log('Sent email', result);
});
```
