### PR TITLE
Clarify what you want for SMTP transporters...

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ app.service('mailer').create(email).then(function (result) {
 const mailer = require('feathers-mailer');
 const nodemailer = require('nodemailer');
 
-const account = await nodemailer.createTestAccount().catch(console.log);
+(async function (app) {
+  const account = await nodemailer.createTestAccount(); // internet required
 
   const transporter = nodemailer.createTransport({
     host: account.smtp.host,
@@ -82,19 +83,17 @@ const account = await nodemailer.createTestAccount().catch(console.log);
 
   app.use('mailer', Mailer(transporter, {from: process.env.FROM_EMAIL});
 
-// Use the service
-const email = {
-   from: 'FROM_EMAIL',
-   to: 'TO_EMAIL',
-   subject: 'SMTP test',
-   html: 'This is the email body'
-};
+  // Use the service
+  const email = {
+     from: account.user, // From email address
+     to: 'president@mars.com',
+     subject: 'SMTP test',
+     html: 'This is the email body'
+  };
 
-app.service('mailer').create(email).then(function (result) {
-  console.log('Sent email', result);
-}).catch(err => {
-  console.log(err);
-});
+  await app.service('mailer').create(email)
+  console.log(`Preview URL: ${nodemailer.getTestMessageUrl(info)}`)
+})(app)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ const nodemailer = require('nodemailer');
     }
   };
 
-  app.use('mailer', Mailer(transporter, {from: process.env.FROM_EMAIL});
+  // Register service and setting default From Email
+  app.use('mailer', Mailer(transporter, { from: account.user });
 
   // Use the service
   const email = {
-     from: account.user, // From email address
      to: 'president@mars.com',
      subject: 'SMTP test',
      html: 'This is the email body'

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ const nodemailer = require('nodemailer');
   };
 
   // Register service and setting default From Email
-  app.use('mailer', Mailer(transporter, { from: account.user });
+  app.use('mailer', mailer(transporter, { from: account.user });
 
   // Use the service
   const email = {

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const mailer = require('feathers-mailer');
 
 See [here](https://nodemailer.com/message/#commmon-fields) for possible fields of `body`.
 
-## Example with Madrill
+## Example with Mandrill
 
 ```js
 const mailer = require('feathers-mailer');

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const mailer = require('feathers-mailer');
 
 See [here](https://nodemailer.com/message/#commmon-fields) for possible fields of `body`.
 
-## Example
+## Example with Madrill
 
 ```js
 const mailer = require('feathers-mailer');
@@ -50,7 +50,43 @@ app.use('/mailer', mailer(mandrill({
 const email = {
    from: 'FROM_EMAIL',
    to: 'TO_EMAIL',
-   subject: 'Sendgrid test',
+   subject: 'Mandrill test',
+   html: 'This is the email body'
+};
+
+app.service('mailer').create(email).then(function (result) {
+  console.log('Sent email', result);
+}).catch(err => {
+  console.log(err);
+});
+```
+
+## Example with Smtp (ethereal)
+
+```js
+const mailer = require('feathers-mailer');
+const nodemailer = require('nodemailer');
+
+const account = await nodemailer.createTestAccount().catch(console.log);
+
+  const transporter = nodemailer.createTransport({
+    host: account.smtp.host,
+    port: account.smtp.port,
+    secure: account.smtp.secure, // 487 only
+    requireTLS: true,
+    auth: {
+      user: account.user, // generated ethereal user
+      pass: account.pass // generated ethereal password
+    }
+  });
+
+  app.use('mailer', Mailer(transporter, {from: process.env.FROM_EMAIL});
+
+// Use the service
+const email = {
+   from: 'FROM_EMAIL',
+   to: 'TO_EMAIL',
+   subject: 'SMTP test',
    html: 'This is the email body'
 };
 

--- a/README.md
+++ b/README.md
@@ -33,35 +33,7 @@ const mailer = require('feathers-mailer');
 
 See [here](https://nodemailer.com/message/#commmon-fields) for possible fields of `body`.
 
-## Example with Mandrill
-
-```js
-const mailer = require('feathers-mailer');
-const mandrill = require('nodemailer-mandrill-transport');
-
-// Register the service, see below for an example
-app.use('/mailer', mailer(mandrill({
-  auth: {
-    apiKey: process.env.MANDRILL_API_KEY
-  }
-})));
-
-// Use the service
-const email = {
-   from: 'FROM_EMAIL',
-   to: 'TO_EMAIL',
-   subject: 'Mandrill test',
-   html: 'This is the email body'
-};
-
-app.service('mailer').create(email).then(function (result) {
-  console.log('Sent email', result);
-}).catch(err => {
-  console.log(err);
-});
-```
-
-## Example with Smtp (ethereal)
+## Example with SMTP (ethereal)
 
 ```js
 const mailer = require('feathers-mailer');
@@ -94,6 +66,34 @@ const nodemailer = require('nodemailer');
   await app.service('mailer').create(email)
   console.log(`Preview URL: ${nodemailer.getTestMessageUrl(info)}`)
 })(app)
+```
+
+## Example with Mandrill
+
+```js
+const mailer = require('feathers-mailer');
+const mandrill = require('nodemailer-mandrill-transport');
+
+// Register the service, see below for an example
+app.use('/mailer', mailer(mandrill({
+  auth: {
+    apiKey: process.env.MANDRILL_API_KEY
+  }
+})));
+
+// Use the service
+const email = {
+   from: 'FROM_EMAIL',
+   to: 'TO_EMAIL',
+   subject: 'Mandrill test',
+   html: 'This is the email body'
+};
+
+app.service('mailer').create(email).then(function (result) {
+  console.log('Sent email', result);
+}).catch(err => {
+  console.log(err);
+});
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const nodemailer = require('nodemailer');
 (async function (app) {
   const account = await nodemailer.createTestAccount(); // internet required
 
-  const transporter = nodemailer.createTransport({
+  const transporter = {
     host: account.smtp.host,
     port: account.smtp.port,
     secure: account.smtp.secure, // 487 only
@@ -51,7 +51,7 @@ const nodemailer = require('nodemailer');
       user: account.user, // generated ethereal user
       pass: account.pass // generated ethereal password
     }
-  });
+  };
 
   app.use('mailer', Mailer(transporter, {from: process.env.FROM_EMAIL});
 


### PR DESCRIPTION
After an hour of breakpointing a tedious connection error... I figured out what mailer actually wants... it's not this (which was my first instinct while converting from vanilla nodemailer):
```
const transporter = nodemailer.createTransport({
...
app.use('mailer', Mailer(transporter)) // WRONG!
```

Which will result in this error:
```
error: Unhandled Rejection at: Promise  Promise {
  <rejected> { Error: connect ECONNREFUSED 127.0.0.1:587
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1159:14)
  errno: 'ECONNREFUSED',
  code: 'ECONNECTION',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 587,
  command: 'CONN' } } Error: connect ECONNREFUSED 127.0.0.1:587
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1159:14)
```

I may also PR a codesandbox.io playground... I'm pretty sure we can do with zero config backed by Ethereal.io